### PR TITLE
Code coverage

### DIFF
--- a/gulp/test/karma.config.js
+++ b/gulp/test/karma.config.js
@@ -14,6 +14,13 @@ export default {
     browsers: ['PhantomJS'],
     port: 9876,
     concurrency: Infinity,
-    reporters: ['progress'],
+    reporters: ['progress', 'coverage'],
+    coverageReporter: {
+        dir: 'dist/coverage',
+        reporters: [
+            { type: 'text' },
+            { type: 'html', subdir: 'html' }
+        ]
+    },
     colors: true
 };

--- a/gulp/test/rollup.config.js
+++ b/gulp/test/rollup.config.js
@@ -2,6 +2,7 @@ import babel from 'rollup-plugin-babel';
 import text from 'rollup-plugin-string';
 import node_resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import istanbul from 'rollup-plugin-istanbul';
 
 export default {
     rollup: {
@@ -10,7 +11,8 @@ export default {
             // Transform ES2015 to ES5, sans module imports/exports
             babel({
                 include: 'src/**/*.js',
-                exclude: 'node_modules/**'
+                exclude: 'node_modules/**',
+                retainLines: true // Sourcemaps are not working correct for coverage, this is a hack to get around that.
             }),
             // Resolve relative HTML imports
             text({
@@ -28,6 +30,11 @@ export default {
             commonjs({
                 include: 'node_modules/**',
                 exclude: 'src/**'
+            }),
+            // Instrument Javascript program code so that code coverage can be determined.
+            istanbul({
+                include: 'src/**/!(*.spec).js',
+                exclude: ['src/**/*.spec.js', 'node_modules/**']
             })
         ]
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.7.2",
+    "babel-istanbul": "^0.7.0",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-rollup": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Seed project for frontend development with PostCSS for CSS, ES2015 for Javascript, Rollup for dependency management, and Angular with Karma+Jasmine for a development framework.",
   "main": "package.json",
   "scripts": {
-    "clean": "rm dist/*",
+    "clean": "rm -r dist/*",
     "prebuild": "npm run clean",
     "build": "gulp build",
     "predevelop": "npm run build",
@@ -25,6 +25,7 @@
     "gulp": "^3.9.1",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
+    "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-rollup-preprocessor": "^2.0.1",
@@ -36,6 +37,7 @@
     "rollup": "^0.25.4",
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-commonjs": "^2.2.1",
+    "rollup-plugin-istanbul": "^1.0.0",
     "rollup-plugin-node-resolve": "^1.5.0",
     "rollup-plugin-string": "^1.0.1"
   },


### PR DESCRIPTION
Finally got good ES2015 code coverage set up, source maps and all. I'm using `rollup-plugin-istanbul` to hook into `rollup`'s transform pipeline, in conjunction with `babel-istanbul` for transpilation and instrumentation of the application code. However, I can't figure out a way to get `babel-istanbul` to package the babel helper functions that babel uses at runtime for transpiled code. So I use the `babel-core` external helpers builder to get the helper functions and inject them at the front of the bundle. Finally, I hook coverage up to `karma` by setting up `karma-coverage` to just report on the instrumented code.